### PR TITLE
Allow nested definitions in extras

### DIFF
--- a/graphene_django_cud/converter.py
+++ b/graphene_django_cud/converter.py
@@ -155,7 +155,6 @@ def convert_django_field_to_input(
 @convert_django_field_to_input.register(models.SlugField)
 @convert_django_field_to_input.register(models.URLField)
 @convert_django_field_to_input.register(models.GenericIPAddressField)
-@convert_django_field_to_input.register(models.FileField)
 @convert_django_field_to_input.register(models.FilePathField)
 def convert_field_to_string_extended(
     field,


### PR DESCRIPTION
Before this change the graphql schema was correct but the mutation ignored the `foreign_key_extras`

```python
class CreateMovie(DjangoCreateMutation):
    class Meta:
        model = Movie
        login_required = True
        many_to_one_extras = {
            'localizations': {
                'exact': {
                    'type': 'auto',
                    'foreign_key_extras': {
                        'coverPhoto': {
                            'type': 'CreateImageInput',
                        },
                    },
                },
            },
        }
```