### PR TITLE
Revert "ID type for primary key input fields"

### DIFF
--- a/graphene_django_cud/mutations/core.py
+++ b/graphene_django_cud/mutations/core.py
@@ -637,8 +637,6 @@ class DjangoCudBase(Mutation):
                     new_value = disambiguate_id(value)
                 elif field_is_many_to_many:
                     new_value = disambiguate_ids(value)
-                elif getattr(field, "primary_key", False):
-                    new_value = disambiguate_id(value)
 
             if field_is_many_to_many:
                 many_to_many_to_set[name] = cls.get_all_objs(field.related_model, new_value)

--- a/graphene_django_cud/util.py
+++ b/graphene_django_cud/util.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 import graphene
 from django.db import models
 from django.db.models import OneToOneRel
-from graphene import InputObjectType, ID
+from graphene import InputObjectType
 from graphene.utils.str_converters import to_camel_case
 from graphene_django.registry import get_global_registry
 from graphene_django.utils import get_model_fields
@@ -149,19 +149,15 @@ def get_input_fields_for_model(
         elif name in required_fields:
             required = True
 
-        if name not in fields:
-            if getattr(field, "primary_key", False):
-                fields[name] = ID(required=True,
-                                  description=getattr(field, "help_text", ""))
-            else:
-                fields[name] = convert_django_field_with_choices(
-                    field,
-                    registry,
-                    required,
-                    many_to_many_extras.get(name, {}).get("exact"),
-                    foreign_key_extras.get(name, {}),
-                    one_to_one_extras.get(name, {}),
-                )
+        converted = convert_django_field_with_choices(
+            field,
+            registry,
+            required,
+            many_to_many_extras.get(name, {}).get("exact"),
+            foreign_key_extras.get(name, {}),
+            one_to_one_extras.get(name, {}),
+        )
+        fields[name] = converted
 
         if type(field) in (models.OneToOneRel, models.OneToOneField):
             one_to_one_fields.append(field)


### PR DESCRIPTION
This will currently break some setups as the ID field is too intrusive by always being required and always being of type ID. A better solution here will have to be put in place.