### PR TITLE
Adds resolve_id() & resolve_ids() methods that can be overriden

### DIFF
--- a/graphene_django_cud/mutations/batch_delete.py
+++ b/graphene_django_cud/mutations/batch_delete.py
@@ -10,7 +10,6 @@ from graphql import GraphQLError
 from graphql_relay import to_global_id
 
 from graphene_django_cud.mutations.core import DjangoCudBase
-from graphene_django_cud.util import disambiguate_ids
 
 
 class DjangoBatchDeleteMutationOptions(MutationOptions):
@@ -99,7 +98,7 @@ class DjangoBatchDeleteMutation(DjangoCudBase):
         cls.check_permissions(root, info, ids)
 
         Model = cls._meta.model
-        ids = disambiguate_ids(ids)
+        ids = cls.resolve_ids(ids)
 
         cls.validate(root, info, ids)
 

--- a/graphene_django_cud/mutations/batch_update.py
+++ b/graphene_django_cud/mutations/batch_update.py
@@ -11,7 +11,7 @@ from graphql import GraphQLError
 
 from graphene_django_cud.mutations.core import DjangoCudBase, DjangoCudBaseOptions
 from graphene_django_cud.registry import get_type_meta_registry
-from graphene_django_cud.util import get_input_fields_for_model, disambiguate_id
+from graphene_django_cud.util import get_input_fields_for_model
 
 
 class DjangoBatchUpdateMutationOptions(DjangoCudBaseOptions):
@@ -181,7 +181,7 @@ class DjangoBatchUpdateMutation(DjangoCudBase):
     @classmethod
     def get_object(cls, root, info, input, full_input):
         return cls.get_queryset(root, info, full_input).get(
-            pk=disambiguate_id(input["id"])
+            pk=cls.resolve_id(input["id"])
         )
 
     @classmethod

--- a/graphene_django_cud/mutations/delete.py
+++ b/graphene_django_cud/mutations/delete.py
@@ -10,7 +10,6 @@ from graphene_django.registry import get_global_registry
 from graphql import GraphQLError
 
 from graphene_django_cud.mutations.core import DjangoCudBase
-from graphene_django_cud.util import disambiguate_id
 
 
 class DjangoDeleteMutationOptions(MutationOptions):
@@ -98,7 +97,7 @@ class DjangoDeleteMutation(DjangoCudBase):
         cls.validate(root, info, id)
 
         Model = cls._meta.model
-        id = disambiguate_id(id)
+        id = cls.resolve_id(id)
 
         try:
             obj = cls.get_queryset(root, info, id).get(pk=id)

--- a/graphene_django_cud/mutations/filter_delete.py
+++ b/graphene_django_cud/mutations/filter_delete.py
@@ -12,7 +12,7 @@ from graphql import GraphQLError
 from graphql_relay import to_global_id
 
 from graphene_django_cud.mutations.core import DjangoCudBase
-from graphene_django_cud.util import get_filter_fields_input_args, disambiguate_id, disambiguate_ids
+from graphene_django_cud.util import get_filter_fields_input_args
 
 
 class DjangoFilterDeleteMutationOptions(MutationOptions):
@@ -147,7 +147,7 @@ class DjangoFilterDeleteMutation(DjangoCudBase):
             if new_value == value and value is not None:
                 if type(field) in (models.ForeignKey, models.OneToOneField):
                     name = getattr(field, "db_column", None) or name + "_id"
-                    new_value = disambiguate_id(value)
+                    new_value = cls.resolve_id(value)
                 elif (
                     type(field)
                     in (
@@ -157,7 +157,7 @@ class DjangoFilterDeleteMutation(DjangoCudBase):
                     )
                     or filter_field_is_list
                 ):
-                    new_value = disambiguate_ids(value)
+                    new_value = cls.resolve_ids(value)
 
             model_field_values[name] = new_value
 

--- a/graphene_django_cud/mutations/filter_update.py
+++ b/graphene_django_cud/mutations/filter_update.py
@@ -14,8 +14,6 @@ from graphql import GraphQLError
 from graphene_django_cud.mutations.core import DjangoCudBase, meta_registry
 from graphene_django_cud.util import (
     get_filter_fields_input_args,
-    disambiguate_id,
-    disambiguate_ids,
     get_input_fields_for_model,
 )
 
@@ -203,7 +201,7 @@ class DjangoFilterUpdateMutation(DjangoCudBase):
             if new_value == value and value is not None:
                 if type(field) in (models.ForeignKey, models.OneToOneField):
                     name = getattr(field, "db_column", None) or name + "_id"
-                    new_value = disambiguate_id(value)
+                    new_value = cls.resolve_id(value)
                 elif (
                     type(field)
                     in (
@@ -213,7 +211,7 @@ class DjangoFilterUpdateMutation(DjangoCudBase):
                     )
                     or filter_field_is_list
                 ):
-                    new_value = disambiguate_ids(value)
+                    new_value = cls.resolve_ids(value)
 
             model_field_values[name] = new_value
 

--- a/graphene_django_cud/mutations/update.py
+++ b/graphene_django_cud/mutations/update.py
@@ -11,8 +11,7 @@ from graphql import GraphQLError
 
 from graphene_django_cud.mutations.core import DjangoCudBaseOptions, DjangoCudBase
 from graphene_django_cud.registry import get_type_meta_registry
-from graphene_django_cud.util import get_input_fields_for_model, disambiguate_id
-
+from graphene_django_cud.util import get_input_fields_for_model
 
 class DjangoUpdateMutationOptions(DjangoCudBaseOptions):
     pass
@@ -179,7 +178,7 @@ class DjangoUpdateMutation(DjangoCudBase):
             raise GraphQLError("Must be logged in to access this mutation.")
 
 
-        id = disambiguate_id(id)
+        id = cls.resolve_id(id)
         Model = cls._meta.model
         queryset = cls.get_queryset(root, info, input, id)
         obj = queryset.get(pk=id)


### PR DESCRIPTION
Hello,

This PR is aimed at making it easier to define our own ID format. Rather than adding more possibilities to `util.disambiguate_id()`, I'd like to see those calls moved to classmethods that could be overridden by subclasses (similar to the `before_mutate()`/`after_save()` hooks).

To preserve backwards-compatibility, I've made it so the base class version of those methods calls `disambiguate_id/s()`

Happy to add tests and/or documentation, too, if someone will kindly point me in the right direction.  

Thanks!