### PR TITLE
Alter documentation of other hooks

### DIFF
--- a/docs/guide/other-hooks.rst
+++ b/docs/guide/other-hooks.rst
@@ -2,65 +2,102 @@
 Other hooks
 ====================
 
-These hooks are class methods of a mutation, which can be overriden with custom behavior.
-
+These hooks are class methods of a mutation, which can be overridden with custom behavior.
 
 ``before_mutate``
 -------------------
 
-The first hook that fires during the mutation process.
+.. list-table::
+  :widths: 25 75 10
+  :header-rows: 1
 
-For create, batch-create, batch-delete and filter-delete mutations, the hook is:
+  * - Mutation
+    - Arguments
+    - Note
+  * - create
+    - cls, root, info, input
+    - 1
+  * - patch/update
+    - cls, root, info, input, id
+    - 1
+  * - delete
+    - cls, root, info, id
+    -
+  * - batch_create
+    - cls, root, info, input
+    - 1
+  * - batch_patch/batch_update
+    - cls, root, info, input
+    - 1
+  * - batch_delete/filter_delete
+    - cls, root, info, input
+    - 1
 
-``before_mutate(cls, root, info, input)``
-
-For update/delete mutations, the hook is
-
-``before_mutate(cls, root, info, input, id)``
-
-In both cases, the hook can modify and return the ``input`` object. Returning ``None``
-will cause the mutation to use the original ``input``.
+| **1:** The hook can modify and return the ``input`` object. Returning ``None`` will cause the mutation to use the original ``input``.
 
 ``before_save``
 -------------------
 
-For create/update/delete mutations, the hook is:
+.. list-table::
+  :widths: 25 75 10
+  :header-rows: 1
 
-``before_save(cls, root, info, input, obj)``
+  * - Mutation
+    - Arguments
+    - Note
+  * - create
+    - cls, root, info, input, obj
+    - 1
+  * - patch/update
+    - cls, root, info, input, id, obj
+    - 1
+  * - delete
+    - cls, root, info, id, obj
+    - 1
+  * - batch_create
+    - cls, root, info, input, created_objects
+    - 2
+  * - batch_patch/batch_update
+    - cls, root, info, input, updated_objects
+    - 2
+  * - batch_delete
+    - cls, root, info, ids, qs_to_delete
+    - 3
+  * - filter_delete
+    - cls, root, info, filter_qs
+    - 3
 
-And can optionally modify and return the ORM object ``obj``.
-
-For batch-create mutations, the hook is:
-
-``before_save(cls, root, info, created_objects)``
-
-For batch-delete and filter-delete, the hook is:
-
-``before_save(cls, root, info, qs_to_delete)``
-
-and 
-
-``before_save(cls, root, info, filter_qs)``
-
-And can optionally modify and return the queryset.
+| **1:** You can optionally modify and return the ORM object ``obj``.
+| **2:** You can optionally modify and return the ORM objects in ``created_objects`` or ``updated_objects``.
+| **3:** You can optionally modify and return the querysets.
 
 ``after_mutate``
 -------------------
 
-For create/update, the hook is:
+.. list-table::
+  :widths: 25 75 10
+  :header-rows: 1
 
-``after_mutate(cls, root, info, obj, return_data)``
+  * - Mutation
+    - Arguments
+    - Note
+  * - create
+    - cls, root, info, input, obj, return_data
+    - 1
+  * - patch/update
+    - cls, root, info, id, input, obj, return_data
+    - 1
+  * - delete
+    - cls, root, info, deleted_id, found
+    -
+  * - batch_create
+    - cls, root, info, input, created_objs, return_data
+    - 1
+  * - batch_patch/batch_update
+    - cls, root, info, input, updated_objs, return_data
+    - 1
+  * - batch_delete/filter_delete
+    - cls, root, info, input, deletion_count, ids
+    -
 
-and for batch-create:
-
-``after_mutate(cls, root, info, created_objs, return_data)``
-
-Both allow you to modify and return the ``return_data`` argument.
-
-For delete, the hook is:
-
-``after_mutate(cls, root, info, deleted_id, found)``
-
-For batch-delete and filter-delete, the hook is:
-
-``after_mutate(cls, root, info, deletion_count, deleted_ids)``
+| **1:** You can modify and return the ``return_data`` argument.


### PR DESCRIPTION
Updates the documentation of "other hooks" to correctly reflect the function signatures. Also reformats the page with tables, to make it more clear.