### PR TITLE
feat: Ensure that before_save always occurs before a save

### DIFF
--- a/docs/guide/custom-fields.rst
+++ b/docs/guide/custom-fields.rst
@@ -32,7 +32,7 @@ in all `handle-` and `hook`-methods.
             }
 
         @classmethod
-        def before_save(cls, root, info, input, id, obj: Dog):
+        def before_save(cls, info, input, obj: Dog):
             if input.get("bark"):
                 obj.bark_count += 1
             return obj

--- a/graphene_django_cud/mutations/batch_create.py
+++ b/graphene_django_cud/mutations/batch_create.py
@@ -161,8 +161,8 @@ class DjangoBatchCreateMutation(DjangoCudBase):
         return super().before_mutate(root, info, input)
 
     @classmethod
-    def before_save(cls, root, info, input, created_objects):
-        return super().before_save(root, info, input, created_objects)
+    def before_save(cls, info, input, obj):
+        return super().before_save(info, input, obj)
 
     @classmethod
     def after_mutate(cls, root, info, input, created_objs, return_data):
@@ -213,10 +213,6 @@ class DjangoBatchCreateMutation(DjangoCudBase):
                     obj = new_obj
 
                 created_objs.append(obj)
-
-            updated_objs = cls.before_save(root, info, input, created_objs)
-            if updated_objs:
-                created_objs = updated_objs
 
         return_data = {cls._meta.return_field_name: created_objs}
         cls.after_mutate(root, info, input, created_objs, return_data)

--- a/graphene_django_cud/mutations/batch_delete.py
+++ b/graphene_django_cud/mutations/batch_delete.py
@@ -72,8 +72,8 @@ class DjangoBatchDeleteMutation(DjangoCudBase):
         return super().before_mutate(root, info, input)
 
     @classmethod
-    def before_save(cls, root, info, ids, qs_to_delete):
-        return super().before_save(root, info, ids, qs_to_delete)
+    def before_save(cls, info, input, obj):
+        return super().before_save(info, input, obj)
 
     @classmethod
     def after_mutate(cls, root, info, ids, deletion_count, deleted_ids):
@@ -104,11 +104,6 @@ class DjangoBatchDeleteMutation(DjangoCudBase):
 
         qs_to_delete = cls.get_queryset(root, info, ids).filter(id__in=ids)
 
-        updated_qs = cls.before_save(root, info, ids, qs_to_delete)
-
-        if updated_qs:
-            qs_to_delete = updated_qs
-
         # Find out which (global) ids are deleted, and which were not found.
         deleted_ids = [
             to_global_id(get_global_registry().get_type_for_model(Model).__name__, id)
@@ -122,7 +117,10 @@ class DjangoBatchDeleteMutation(DjangoCudBase):
 
         missed_ids = list(set(all_global_ids).difference(deleted_ids))
 
-        deletion_count, _ = qs_to_delete.delete()
+        deletion_count = len(qs_to_delete)
+        for obj in qs_to_delete:
+            cls.before_save(info, None, obj)
+            obj.delete()
 
         cls.after_mutate(root, info, ids, deletion_count, deleted_ids)
 

--- a/graphene_django_cud/mutations/batch_update.py
+++ b/graphene_django_cud/mutations/batch_update.py
@@ -167,8 +167,8 @@ class DjangoBatchUpdateMutation(DjangoCudBase):
         return super().before_mutate(root, info, input)
 
     @classmethod
-    def before_save(cls, root, info, input, updated_objects):
-        return super().before_save(root, info, input, updated_objects)
+    def before_save(cls, info, input, obj):
+        return super().before_save(info, input, obj)
 
     @classmethod
     def after_mutate(cls, root, info, input, updated_objs, return_data):
@@ -229,11 +229,8 @@ class DjangoBatchUpdateMutation(DjangoCudBase):
 
                 updated_objs.append(obj)
 
-            before_save_updated_objs = cls.before_save(root, info, input, updated_objs)
-            if before_save_updated_objs:
-                updated_objs = before_save_updated_objs
-
             for obj in updated_objs:
+                cls.before_save(info, input, obj)
                 obj.save()
 
         return_data = {cls._meta.return_field_name: updated_objs}

--- a/graphene_django_cud/mutations/core.py
+++ b/graphene_django_cud/mutations/core.py
@@ -392,7 +392,9 @@ class DjangoCudBase(Mutation):
             model_field_values[name + "_id"] = obj_id
 
         # Foreign keys are added, we are ready to create our object
-        obj = Model.objects.create(**model_field_values)
+        obj = Model(**model_field_values)
+        cls.before_save(info, input, obj)
+        obj.save()
 
         # Handle one to one rels
         if len(one_to_one_rels) > 0:
@@ -804,8 +806,8 @@ class DjangoCudBase(Mutation):
         return None
 
     @classmethod
-    def before_save(cls, root, info, *args, **kwargs):
-        return None
+    def before_save(cls, info, input, obj):
+        return obj
 
     @classmethod
     def after_mutate(cls, root, info, *args, **kwargs):

--- a/graphene_django_cud/mutations/create.py
+++ b/graphene_django_cud/mutations/create.py
@@ -153,8 +153,8 @@ class DjangoCreateMutation(DjangoCudBase):
         return super().before_mutate(root, info, input)
 
     @classmethod
-    def before_save(cls, root, info, input, obj):
-        return super().before_save(root, info, input, obj)
+    def before_save(cls, info, input, obj):
+        return super().before_save(info, input, obj)
 
     @classmethod
     def after_mutate(cls, root, info, input, obj, return_data):
@@ -191,10 +191,6 @@ class DjangoCreateMutation(DjangoCudBase):
                 cls._meta.one_to_one_extras,
                 Model,
             )
-            updated_obj = cls.before_save(root, info, input, obj)
-            if updated_obj:
-                updated_obj.save()
-                obj = updated_obj
 
         return_data = {cls._meta.return_field_name: obj}
         cls.after_mutate(root, info, input, obj, return_data)

--- a/graphene_django_cud/mutations/delete.py
+++ b/graphene_django_cud/mutations/delete.py
@@ -79,8 +79,8 @@ class DjangoDeleteMutation(DjangoCudBase):
         return super().before_mutate(root, info, id)
 
     @classmethod
-    def before_save(cls, root, info, id, obj):
-        return super().before_save(root, info, id, obj)
+    def before_save(cls, info, input, obj):
+        return super().before_save(info, input, obj)
 
     @classmethod
     def after_mutate(cls, root, info, deleted_id, found):
@@ -122,9 +122,7 @@ class DjangoDeleteMutation(DjangoCudBase):
             obj = cls.get_queryset(root, info, id).get(pk=resolved_id)
             cls.check_permissions(root, info, id, obj)
 
-            updated_obj = cls.before_save(root, info, id, obj)
-            if updated_obj:
-                obj = updated_obj
+            obj = cls.before_save(info, None, obj)
 
             return_id = cls.get_return_id(obj)
             raw_id = obj.id

--- a/graphene_django_cud/mutations/update.py
+++ b/graphene_django_cud/mutations/update.py
@@ -157,8 +157,8 @@ class DjangoUpdateMutation(DjangoCudBase):
         return super().before_mutate(root, info, input, id)
 
     @classmethod
-    def before_save(cls, root, info, input, id, obj):
-        return super().before_save(root, info, input, id, obj)
+    def before_save(cls, info, input, obj):
+        return super().before_save(info, input, obj)
 
     @classmethod
     def after_mutate(cls, root, info, id, input, obj, return_data):
@@ -201,7 +201,7 @@ class DjangoUpdateMutation(DjangoCudBase):
                 Model,
             )
 
-            updated_obj = cls.before_save(root, info, input, id, obj)
+            updated_obj = cls.before_save(info, input, obj)
 
             if updated_obj:
                 obj = updated_obj

--- a/graphene_django_cud/tests/test_create_mutation.py
+++ b/graphene_django_cud/tests/test_create_mutation.py
@@ -628,7 +628,7 @@ class TestCreateMutationCustomFields(TestCase):
                 }
 
             @classmethod
-            def before_save(cls, root, info, input, obj):
+            def before_save(cls, info, input, obj):
                 if input.get("bark"):
                     obj.bark_count += 1
                 return obj

--- a/graphene_django_cud/tests/test_patch_mutation.py
+++ b/graphene_django_cud/tests/test_patch_mutation.py
@@ -1531,7 +1531,7 @@ class TestPatchMutationCustomFields(TestCase):
                 }
 
             @classmethod
-            def before_save(cls, root, info, input, id, obj: Dog):
+            def before_save(cls, info, input, obj: Dog):
                 if input.get("bark"):
                     obj.bark_count += 1
                 return obj

--- a/graphene_django_cud/tests/test_update_mutation.py
+++ b/graphene_django_cud/tests/test_update_mutation.py
@@ -1547,7 +1547,7 @@ class TestUpdateMutationCustomFields(TestCase):
                 }
 
             @classmethod
-            def before_save(cls, root, info, input, id, obj: Dog):
+            def before_save(cls, info, input, obj: Dog):
                 if input.get("bark"):
                     obj.bark_count += 1
                 return obj


### PR DESCRIPTION
We've noticed that in some of the mutations, the before_save trigger actually happens after save. This PR request has a proposed refactor:

Changes:
- Ensure that the `before_save` function always takes place before save.
- Refactor the code so that the `before_save` function takes a consistent set of parameters (currently it sometimes takes a query set and sometimes an object) and always returns a consistent value (the object that will be created, updated, or deleted). Note: this is a backward-incompatible change but was needed to achieve our implementation of the first item.

 Still to-do:
 - Write tests that ensure before_save happens before.