### PR TITLE
Respect required_fields in Patch and BatchPatch mutations

### DIFF
--- a/graphene_django_cud/mutations/batch_patch.py
+++ b/graphene_django_cud/mutations/batch_patch.py
@@ -29,8 +29,8 @@ class DjangoBatchPatchMutation(DjangoBatchUpdateMutation):
         if optional_fields is None:
             optional_fields = all_field_names
 
-            if required_fields is not None:
-                optional_fields = tuple(set(optional_fields) - set(required_fields))
+        if required_fields is not None:
+            optional_fields = tuple(set(optional_fields) - set(required_fields))
 
         input_type_name = type_name or f"BatchPatch{model.__name__}Input"
 

--- a/graphene_django_cud/mutations/batch_patch.py
+++ b/graphene_django_cud/mutations/batch_patch.py
@@ -20,6 +20,7 @@ class DjangoBatchPatchMutation(DjangoBatchUpdateMutation):
             _meta=None,
             model=None,
             optional_fields=None,
+            required_fields=None,
             type_name=None,
             **kwargs
     ):
@@ -28,12 +29,16 @@ class DjangoBatchPatchMutation(DjangoBatchUpdateMutation):
         if optional_fields is None:
             optional_fields = all_field_names
 
+            if required_fields is not None:
+                optional_fields = tuple(set(optional_fields) - set(required_fields))
+
         input_type_name = type_name or f"BatchPatch{model.__name__}Input"
 
         return super().__init_subclass_with_meta__(
             _meta=_meta,
             model=model,
             optional_fields=optional_fields,
+            required_fields=required_fields,
             type_name=input_type_name,
             **kwargs
         )

--- a/graphene_django_cud/mutations/patch.py
+++ b/graphene_django_cud/mutations/patch.py
@@ -19,6 +19,7 @@ class DjangoPatchMutation(DjangoUpdateMutation):
         _meta=None,
         model=None,
         optional_fields=None,
+        required_fields=None,
         type_name=None,
         **kwargs
     ):
@@ -27,12 +28,16 @@ class DjangoPatchMutation(DjangoUpdateMutation):
         if optional_fields is None:
             optional_fields = all_field_names
 
+            if required_fields is not None:
+                optional_fields = tuple(set(optional_fields) - set(required_fields))
+
         input_type_name = type_name or f"Patch{model.__name__}Input"
 
         return super().__init_subclass_with_meta__(
             _meta=_meta,
             model=model,
             optional_fields=optional_fields,
+            required_fields=required_fields,
             type_name=input_type_name,
             **kwargs
         )

--- a/graphene_django_cud/mutations/patch.py
+++ b/graphene_django_cud/mutations/patch.py
@@ -28,8 +28,8 @@ class DjangoPatchMutation(DjangoUpdateMutation):
         if optional_fields is None:
             optional_fields = all_field_names
 
-            if required_fields is not None:
-                optional_fields = tuple(set(optional_fields) - set(required_fields))
+        if required_fields is not None:
+            optional_fields = tuple(set(optional_fields) - set(required_fields))
 
         input_type_name = type_name or f"Patch{model.__name__}Input"
 

--- a/graphene_django_cud/tests/test_batch_patch_mutation.py
+++ b/graphene_django_cud/tests/test_batch_patch_mutation.py
@@ -32,7 +32,7 @@ class TestBatchPatchMutation(TestCase):
                 $input: [BatchPatchDogInput]! 
             ){
                 batchPatchDog(input: $input){
-                    dogs{
+                    dogs {
                         id
                         name
                     }
@@ -68,3 +68,88 @@ class TestBatchPatchMutation(TestCase):
         dog_2.refresh_from_db()
         self.assertEqual("New name 1", dog_1.name)
         self.assertEqual("New name 2", dog_2.name)
+
+
+class TestBatchPatchMutationRequiredFields(TestCase):
+    def setUp(self):
+        # This registers the UserNode type
+        # noinspection PyUnresolvedReferences
+        from .schema import UserNode
+
+        class PatchDogMutation(DjangoBatchPatchMutation):
+            class Meta:
+                model = Dog
+                required_fields = ("owner",)
+
+        class Mutations(graphene.ObjectType):
+            batch_patch_dog = PatchDogMutation.Field()
+
+        self.user1 = UserFactory.create()
+        self.user2 = UserFactory.create()
+        self.dog1 = DogFactory.create(owner=self.user1)
+        self.dog2 = DogFactory.create(owner=self.user2)
+
+        self.user1_id = to_global_id("UserNode", self.user1.id)
+        self.user2_id = to_global_id("UserNode", self.user2.id)
+        self.dog1_id = to_global_id("DogNode", self.dog1.id)
+        self.dog2_id = to_global_id("DogNode", self.dog2.id)
+
+        self.schema = Schema(mutation=Mutations)
+        self.mutation = """
+            mutation BatchPatchDog(
+                $input: [BatchPatchDogInput]!
+            ){
+                batchPatchDog(input: $input){
+                    dogs {
+                        id
+                    }
+                }
+            }
+        """
+        self.context = Dict(user=self.user1)
+
+    def test_required_fields__when_set_and_not_provided__returns_error(self):
+        result = self.schema.execute(
+            self.mutation,
+            variables={
+                "id": to_global_id("DogNode", self.dog1.id),
+                "input": [
+                    {
+                        "id": self.dog1_id,
+                        "name": "Lassie",
+                    },
+                    {
+                        "id": self.dog2_id,
+                        "name": "Richard",
+                    }
+                ]
+            },
+            context=self.context,
+        )
+        self.assertIsNotNone(result.errors)
+
+    def test_required_fields__when_set_and_provided__returns_no_error(self):
+        result = self.schema.execute(
+            self.mutation,
+            variables={
+                "input": [
+                    {
+                        "id": self.dog1_id,
+                        "name": "Lassie",
+                        "owner": self.user2_id,
+                    },
+                    {
+                        "id": self.dog2_id,
+                        "name": "Richard",
+                        "owner": self.user1_id,
+                    }
+                ]
+            },
+            context=self.context,
+        )
+        self.assertIsNone(result.errors)
+
+        self.dog1.refresh_from_db()
+        self.dog2.refresh_from_db()
+        self.assertEqual(self.dog1.owner.id, self.user2.id)
+        self.assertEqual(self.dog2.owner.id, self.user1.id)


### PR DESCRIPTION
Fields mentioned in `required_fields` on `DjangoPatchMutation` and `DjangoBatchPatchMutation` are now set as required in the schema. Tests included.