### PR TITLE
feature (delete): added perform_delete function

### DIFF
--- a/graphene_django_cud/mutations/delete.py
+++ b/graphene_django_cud/mutations/delete.py
@@ -105,6 +105,10 @@ class DjangoDeleteMutation(DjangoCudBase):
             return obj.pk
 
     @classmethod
+    def perform_delete(cls, obj):
+        obj.delete()
+
+    @classmethod
     def mutate(cls, root, info, id):
         cls.before_mutate(root, info, id)
 
@@ -125,7 +129,7 @@ class DjangoDeleteMutation(DjangoCudBase):
 
             return_id = cls.get_return_id(obj)
             raw_id = obj.pk
-            obj.delete()
+            cls.perform_delete(obj)
             cls.after_mutate(root, info, id, True)
             return cls(
                 found=True,


### PR DESCRIPTION
Adds `perform_delete` function to `DjangoDeleteMutation`

In my project we use `soft_delete` rather than hard-delete on our models, and this PR would allow us to override only the delete logic without needing to copy the rest of the mutate function. Useful for allowing people to change the how the delete operation is carried out on their models, without overriding too much of the mutate logic