### PR TITLE
Add required_output_field mutation option

### DIFF
--- a/docs/guide/required-output-field.rst
+++ b/docs/guide/required-output-field.rst
@@ -1,0 +1,31 @@
+.. _required_output_field:
+
+================================
+Required output field
+================================
+
+*This section is not relevant for delete and batch delete mutations.*
+
+For the below mutation, the type of ``fish`` will by default be ``FishNode``,
+meaning it will be nullable.
+
+.. code::
+
+    mutation CreateFish($input: CreateFishInput!) {
+      createFish(input: $input) {
+        fish {
+          id
+          name
+        }
+      }
+    }
+
+If you rather want the type to be ``FishNode!`` (non-nullable), you can specify
+the required_output_field in the mutation meta, like so:
+
+.. code-block:: python
+
+    class CreateFishMutation(DjangoCreateMutation):
+        class Meta:
+            model = Fish
+            required_output_field = True

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,7 @@ helper classes designed to fast-track creation of create, update and delete muta
    guide/naming
    guide/field-types
    guide/custom-fields
+   guide/required-output-field
    guide/reusing-types
    guide/limitations
 

--- a/graphene_django_cud/mutations/batch_create.py
+++ b/graphene_django_cud/mutations/batch_create.py
@@ -46,6 +46,7 @@ class DjangoBatchCreateMutation(DjangoCudBase):
         use_type_name=None,
         field_types=None,
         custom_fields=None,
+        required_output_field=False,
         **kwargs,
     ):
         registry = get_global_registry()
@@ -140,7 +141,7 @@ class DjangoBatchCreateMutation(DjangoCudBase):
         arguments = OrderedDict(input=graphene.List(InputType, required=True))
 
         output_fields = OrderedDict()
-        output_fields[return_field_name] = graphene.List(model_type)
+        output_fields[return_field_name] = graphene.List(model_type, required=required_output_field)
 
         if _meta is None:
             _meta = DjangoBatchCreateMutationOptions(cls)

--- a/graphene_django_cud/mutations/batch_create.py
+++ b/graphene_django_cud/mutations/batch_create.py
@@ -141,7 +141,9 @@ class DjangoBatchCreateMutation(DjangoCudBase):
         arguments = OrderedDict(input=graphene.List(InputType, required=True))
 
         output_fields = OrderedDict()
-        output_fields[return_field_name] = graphene.List(model_type, required=required_output_field)
+        output_fields[return_field_name] = graphene.List(
+            model_type if not required_output_field else graphene.NonNull(model_type), required=required_output_field
+        )
 
         if _meta is None:
             _meta = DjangoBatchCreateMutationOptions(cls)

--- a/graphene_django_cud/mutations/batch_update.py
+++ b/graphene_django_cud/mutations/batch_update.py
@@ -142,7 +142,9 @@ class DjangoBatchUpdateMutation(DjangoCudBase):
         arguments = OrderedDict(input=graphene.List(InputType, required=True))
 
         output_fields = OrderedDict()
-        output_fields[return_field_name] = graphene.List(model_type, required=required_output_field)
+        output_fields[return_field_name] = graphene.List(
+            model_type if not required_output_field else graphene.NonNull(model_type), required=required_output_field
+        )
 
         if _meta is None:
             _meta = DjangoBatchUpdateMutationOptions(cls)

--- a/graphene_django_cud/mutations/batch_update.py
+++ b/graphene_django_cud/mutations/batch_update.py
@@ -46,6 +46,7 @@ class DjangoBatchUpdateMutation(DjangoCudBase):
         use_type_name=None,
         field_types=None,
         custom_fields=None,
+        required_output_field=False,
         **kwargs,
     ):
         registry = get_global_registry()
@@ -141,7 +142,7 @@ class DjangoBatchUpdateMutation(DjangoCudBase):
         arguments = OrderedDict(input=graphene.List(InputType, required=True))
 
         output_fields = OrderedDict()
-        output_fields[return_field_name] = graphene.List(model_type)
+        output_fields[return_field_name] = graphene.List(model_type, required=required_output_field)
 
         if _meta is None:
             _meta = DjangoBatchUpdateMutationOptions(cls)

--- a/graphene_django_cud/mutations/core.py
+++ b/graphene_django_cud/mutations/core.py
@@ -805,3 +805,5 @@ class DjangoCudBaseOptions(MutationOptions):
     field_types = None
 
     custom_fields = None
+
+    required_output_field = None

--- a/graphene_django_cud/mutations/create.py
+++ b/graphene_django_cud/mutations/create.py
@@ -46,6 +46,7 @@ class DjangoCreateMutation(DjangoCudBase):
         field_types=None,
         ignore_primary_key=True,
         custom_fields=None,
+        required_output_field=False,
         **kwargs,
     ):
         registry = get_global_registry()
@@ -134,7 +135,7 @@ class DjangoCreateMutation(DjangoCudBase):
         arguments = OrderedDict(input=InputType(required=True))
 
         output_fields = OrderedDict()
-        output_fields[return_field_name] = graphene.Field(model_type)
+        output_fields[return_field_name] = graphene.Field(model_type, required=required_output_field)
 
         if _meta is None:
             _meta = DjangoCreateMutationOptions(cls)

--- a/graphene_django_cud/mutations/filter_update.py
+++ b/graphene_django_cud/mutations/filter_update.py
@@ -49,6 +49,7 @@ class DjangoFilterUpdateMutation(DjangoCudBase):
         required_fields=(),
         field_types=None,
         auto_context_fields=None,
+        required_output_field=False,
         **kwargs,
     ):
 
@@ -129,7 +130,7 @@ class DjangoFilterUpdateMutation(DjangoCudBase):
 
         output_fields = OrderedDict()
         output_fields["updated_count"] = graphene.Int()
-        output_fields["updated_objects"] = graphene.List(model_type)
+        output_fields["updated_objects"] = graphene.List(model_type, required=required_output_field)
 
         if _meta is None:
             _meta = DjangoFilterUpdateMutationOptions(cls)

--- a/graphene_django_cud/mutations/filter_update.py
+++ b/graphene_django_cud/mutations/filter_update.py
@@ -130,7 +130,9 @@ class DjangoFilterUpdateMutation(DjangoCudBase):
 
         output_fields = OrderedDict()
         output_fields["updated_count"] = graphene.Int()
-        output_fields["updated_objects"] = graphene.List(model_type, required=required_output_field)
+        output_fields["updated_objects"] = graphene.List(
+            model_type if not required_output_field else graphene.NonNull(model_type), required=required_output_field
+        )
 
         if _meta is None:
             _meta = DjangoFilterUpdateMutationOptions(cls)

--- a/graphene_django_cud/mutations/update.py
+++ b/graphene_django_cud/mutations/update.py
@@ -45,6 +45,7 @@ class DjangoUpdateMutation(DjangoCudBase):
         field_types=None,
         custom_fields=None,
         use_select_for_update=True,
+        required_output_field=False,
         **kwargs,
     ):
         registry = get_global_registry()
@@ -132,7 +133,7 @@ class DjangoUpdateMutation(DjangoCudBase):
         arguments = OrderedDict(id=graphene.ID(required=True), input=InputType(required=True))
 
         output_fields = OrderedDict()
-        output_fields[return_field_name] = graphene.Field(model_type)
+        output_fields[return_field_name] = graphene.Field(model_type, required=required_output_field)
 
         if _meta is None:
             _meta = DjangoUpdateMutationOptions(cls)

--- a/graphene_django_cud/tests/test_batch_create_mutation.py
+++ b/graphene_django_cud/tests/test_batch_create_mutation.py
@@ -5,10 +5,11 @@ from graphene import Schema
 from graphene_django_cud.mutations import DjangoBatchCreateMutation
 from graphene_django_cud.tests.dummy_query import DummyQuery
 from graphene_django_cud.tests.models import Fish
+from graphene_django_cud.tests.util import get_introspected_field_kind, get_introspected_list_field_item_kind
 
 
 class TestBatchCreateMutationRequiredOutputField(TestCase):
-    def test__patch_mutation_with_required_output_field(self):
+    def test__batch_create_mutation_with_required_output_field(self):
         # This register the FishNode type
         from .schema import FishNode  # noqa: F401
 
@@ -22,21 +23,13 @@ class TestBatchCreateMutationRequiredOutputField(TestCase):
 
         schema = Schema(query=DummyQuery, mutation=Mutations)
 
-        introspected = schema.introspect()
-        introspected_types = introspected.get("__schema", {}).get("types", [])
-        introspected_mutation = next(
-            filter(lambda t: t.get("name", None) == "BatchCreateFishMutation", introspected_types), {}
-        )
+        field_kind = get_introspected_field_kind(schema, "BatchCreateFishMutation", "fishs")
+        self.assertEqual(field_kind, "NON_NULL")
 
-        self.assertIsNotNone(introspected_mutation)
+        field_item_kind = get_introspected_list_field_item_kind(schema, "BatchCreateFishMutation", "fishs")
+        self.assertEqual(field_item_kind, "NON_NULL")
 
-        introspected_fields = introspected_mutation.get("fields", [])
-        introspected_field = next(filter(lambda f: f.get("name", None) == "fishs", introspected_fields), {})
-        introspected_field_type = introspected_field.get("type", {}).get("kind", None)
-
-        self.assertEqual(introspected_field_type, "NON_NULL")
-
-    def test__patch_mutation_without_required_output_field(self):
+    def test__batch_create_mutation_without_required_output_field(self):
         # This register the FishNode type
         from .schema import FishNode  # noqa: F401
 
@@ -50,16 +43,5 @@ class TestBatchCreateMutationRequiredOutputField(TestCase):
 
         schema = Schema(query=DummyQuery, mutation=Mutations)
 
-        introspected = schema.introspect()
-        introspected_types = introspected.get("__schema", {}).get("types", [])
-        introspected_mutation = next(
-            filter(lambda t: t.get("name", None) == "BatchCreateFishMutation", introspected_types), {}
-        )
-
-        self.assertIsNotNone(introspected_mutation)
-
-        introspected_fields = introspected_mutation.get("fields", [])
-        introspected_field = next(filter(lambda f: f.get("name", None) == "fishs", introspected_fields), {})
-        introspected_field_type = introspected_field.get("type", {}).get("kind", None)
-
-        self.assertNotEqual(introspected_field_type, "NON_NULL")
+        field_kind = get_introspected_field_kind(schema, "BatchCreateFishMutation", "fishs")
+        self.assertNotEqual(field_kind, "NON_NULL")

--- a/graphene_django_cud/tests/test_batch_create_mutation.py
+++ b/graphene_django_cud/tests/test_batch_create_mutation.py
@@ -1,0 +1,65 @@
+import graphene
+from django.test import TestCase
+from graphene import Schema
+
+from graphene_django_cud.mutations import DjangoBatchCreateMutation
+from graphene_django_cud.tests.dummy_query import DummyQuery
+from graphene_django_cud.tests.models import Fish
+
+
+class TestBatchCreateMutationRequiredOutputField(TestCase):
+    def test__patch_mutation_with_required_output_field(self):
+        # This register the FishNode type
+        from .schema import FishNode  # noqa: F401
+
+        class BatchCreateFishMutation(DjangoBatchCreateMutation):
+            class Meta:
+                model = Fish
+                required_output_field = True
+
+        class Mutations(graphene.ObjectType):
+            batch_create_fish = BatchCreateFishMutation.Field()
+
+        schema = Schema(query=DummyQuery, mutation=Mutations)
+
+        introspected = schema.introspect()
+        introspected_types = introspected.get("__schema", {}).get("types", [])
+        introspected_mutation = next(
+            filter(lambda t: t.get("name", None) == "BatchCreateFishMutation", introspected_types), {}
+        )
+
+        self.assertIsNotNone(introspected_mutation)
+
+        introspected_fields = introspected_mutation.get("fields", [])
+        introspected_field = next(filter(lambda f: f.get("name", None) == "fishs", introspected_fields), {})
+        introspected_field_type = introspected_field.get("type", {}).get("kind", None)
+
+        self.assertEqual(introspected_field_type, "NON_NULL")
+
+    def test__patch_mutation_without_required_output_field(self):
+        # This register the FishNode type
+        from .schema import FishNode  # noqa: F401
+
+        class BatchCreateFishMutation(DjangoBatchCreateMutation):
+            class Meta:
+                model = Fish
+                required_output_field = False
+
+        class Mutations(graphene.ObjectType):
+            batch_create_fish = BatchCreateFishMutation.Field()
+
+        schema = Schema(query=DummyQuery, mutation=Mutations)
+
+        introspected = schema.introspect()
+        introspected_types = introspected.get("__schema", {}).get("types", [])
+        introspected_mutation = next(
+            filter(lambda t: t.get("name", None) == "BatchCreateFishMutation", introspected_types), {}
+        )
+
+        self.assertIsNotNone(introspected_mutation)
+
+        introspected_fields = introspected_mutation.get("fields", [])
+        introspected_field = next(filter(lambda f: f.get("name", None) == "fishs", introspected_fields), {})
+        introspected_field_type = introspected_field.get("type", {}).get("kind", None)
+
+        self.assertNotEqual(introspected_field_type, "NON_NULL")

--- a/graphene_django_cud/tests/test_batch_patch_mutation.py
+++ b/graphene_django_cud/tests/test_batch_patch_mutation.py
@@ -152,3 +152,61 @@ class TestBatchPatchMutationRequiredFields(TestCase):
         self.dog2.refresh_from_db()
         self.assertEqual(self.dog1.owner.id, self.user2.id)
         self.assertEqual(self.dog2.owner.id, self.user1.id)
+
+
+class TestBatchPatchMutationRequiredOutputField(TestCase):
+    def test__patch_mutation_with_required_output_field(self):
+        # This register the DogNode type
+        from .schema import DogNode  # noqa: F401
+
+        class BatchPatchDogMutation(DjangoBatchPatchMutation):
+            class Meta:
+                model = Dog
+                required_output_field = True
+
+        class Mutations(graphene.ObjectType):
+            patch_dog = BatchPatchDogMutation.Field()
+
+        schema = Schema(query=DummyQuery, mutation=Mutations)
+
+        introspected = schema.introspect()
+        introspected_types = introspected.get("__schema", {}).get("types", [])
+        introspected_mutation = next(
+            filter(lambda t: t.get("name", None) == "BatchPatchDogMutation", introspected_types), {}
+        )
+
+        self.assertIsNotNone(introspected_mutation)
+
+        introspected_fields = introspected_mutation.get("fields", [])
+        introspected_field = next(filter(lambda f: f.get("name", None) == "dogs", introspected_fields), {})
+        introspected_field_type = introspected_field.get("type", {}).get("kind", None)
+
+        self.assertEqual(introspected_field_type, "NON_NULL")
+
+    def test__patch_mutation_without_required_output_field(self):
+        # This register the DogNode type
+        from .schema import DogNode  # noqa: F401
+
+        class BatchPatchDogMutation(DjangoBatchPatchMutation):
+            class Meta:
+                model = Dog
+                required_output_field = False
+
+        class Mutations(graphene.ObjectType):
+            create_fish = BatchPatchDogMutation.Field()
+
+        schema = Schema(query=DummyQuery, mutation=Mutations)
+
+        introspected = schema.introspect()
+        introspected_types = introspected.get("__schema", {}).get("types", [])
+        introspected_mutation = next(
+            filter(lambda t: t.get("name", None) == "BatchPatchDogMutation", introspected_types), {}
+        )
+
+        self.assertIsNotNone(introspected_mutation)
+
+        introspected_fields = introspected_mutation.get("fields", [])
+        introspected_field = next(filter(lambda f: f.get("name", None) == "dogs", introspected_fields), {})
+        introspected_field_type = introspected_field.get("type", {}).get("kind", None)
+
+        self.assertNotEqual(introspected_field_type, "NON_NULL")

--- a/graphene_django_cud/tests/test_batch_patch_mutation.py
+++ b/graphene_django_cud/tests/test_batch_patch_mutation.py
@@ -8,6 +8,7 @@ from graphene_django_cud.mutations.batch_patch import DjangoBatchPatchMutation
 from graphene_django_cud.tests.factories import DogFactory, UserFactory
 from graphene_django_cud.tests.dummy_query import DummyQuery
 from graphene_django_cud.tests.models import Dog
+from graphene_django_cud.tests.util import get_introspected_field_kind, get_introspected_list_field_item_kind
 
 
 class TestBatchPatchMutation(TestCase):
@@ -155,7 +156,7 @@ class TestBatchPatchMutationRequiredFields(TestCase):
 
 
 class TestBatchPatchMutationRequiredOutputField(TestCase):
-    def test__patch_mutation_with_required_output_field(self):
+    def test__batch_patch_mutation_with_required_output_field(self):
         # This register the DogNode type
         from .schema import DogNode  # noqa: F401
 
@@ -165,25 +166,17 @@ class TestBatchPatchMutationRequiredOutputField(TestCase):
                 required_output_field = True
 
         class Mutations(graphene.ObjectType):
-            patch_dog = BatchPatchDogMutation.Field()
+            batch_patch_dog = BatchPatchDogMutation.Field()
 
         schema = Schema(query=DummyQuery, mutation=Mutations)
 
-        introspected = schema.introspect()
-        introspected_types = introspected.get("__schema", {}).get("types", [])
-        introspected_mutation = next(
-            filter(lambda t: t.get("name", None) == "BatchPatchDogMutation", introspected_types), {}
-        )
+        field_kind = get_introspected_field_kind(schema, "BatchPatchDogMutation", "dogs")
+        self.assertEqual(field_kind, "NON_NULL")
 
-        self.assertIsNotNone(introspected_mutation)
+        field_item_kind = get_introspected_list_field_item_kind(schema, "BatchPatchDogMutation", "dogs")
+        self.assertEqual(field_item_kind, "NON_NULL")
 
-        introspected_fields = introspected_mutation.get("fields", [])
-        introspected_field = next(filter(lambda f: f.get("name", None) == "dogs", introspected_fields), {})
-        introspected_field_type = introspected_field.get("type", {}).get("kind", None)
-
-        self.assertEqual(introspected_field_type, "NON_NULL")
-
-    def test__patch_mutation_without_required_output_field(self):
+    def test__batch_patch_mutation_without_required_output_field(self):
         # This register the DogNode type
         from .schema import DogNode  # noqa: F401
 
@@ -193,20 +186,9 @@ class TestBatchPatchMutationRequiredOutputField(TestCase):
                 required_output_field = False
 
         class Mutations(graphene.ObjectType):
-            create_fish = BatchPatchDogMutation.Field()
+            batch_patch_dog = BatchPatchDogMutation.Field()
 
         schema = Schema(query=DummyQuery, mutation=Mutations)
 
-        introspected = schema.introspect()
-        introspected_types = introspected.get("__schema", {}).get("types", [])
-        introspected_mutation = next(
-            filter(lambda t: t.get("name", None) == "BatchPatchDogMutation", introspected_types), {}
-        )
-
-        self.assertIsNotNone(introspected_mutation)
-
-        introspected_fields = introspected_mutation.get("fields", [])
-        introspected_field = next(filter(lambda f: f.get("name", None) == "dogs", introspected_fields), {})
-        introspected_field_type = introspected_field.get("type", {}).get("kind", None)
-
-        self.assertNotEqual(introspected_field_type, "NON_NULL")
+        field_kind = get_introspected_field_kind(schema, "BatchPatchDogMutation", "dogs")
+        self.assertNotEqual(field_kind, "NON_NULL")

--- a/graphene_django_cud/tests/test_batch_update_mutation.py
+++ b/graphene_django_cud/tests/test_batch_update_mutation.py
@@ -8,6 +8,7 @@ from graphene_django_cud.mutations.batch_update import DjangoBatchUpdateMutation
 from graphene_django_cud.tests.factories import DogFactory, UserFactory
 from graphene_django_cud.tests.dummy_query import DummyQuery
 from graphene_django_cud.tests.models import Dog
+from graphene_django_cud.tests.util import get_introspected_field_kind, get_introspected_list_field_item_kind
 
 
 class TestBatchUpdateMutation(TestCase):
@@ -91,19 +92,11 @@ class TestBatchUpdateMutationRequiredOutputField(TestCase):
 
         schema = Schema(query=DummyQuery, mutation=Mutations)
 
-        introspected = schema.introspect()
-        introspected_types = introspected.get("__schema", {}).get("types", [])
-        introspected_mutation = next(
-            filter(lambda t: t.get("name", None) == "BatchUpdateDogMutation", introspected_types), {}
-        )
+        field_kind = get_introspected_field_kind(schema, "BatchUpdateDogMutation", "dogs")
+        self.assertEqual(field_kind, "NON_NULL")
 
-        self.assertIsNotNone(introspected_mutation)
-
-        introspected_fields = introspected_mutation.get("fields", [])
-        introspected_field = next(filter(lambda f: f.get("name", None) == "dogs", introspected_fields), {})
-        introspected_field_type = introspected_field.get("type", {}).get("kind", None)
-
-        self.assertEqual(introspected_field_type, "NON_NULL")
+        field_item_kind = get_introspected_list_field_item_kind(schema, "BatchUpdateDogMutation", "dogs")
+        self.assertEqual(field_item_kind, "NON_NULL")
 
     def test__patch_mutation_without_required_output_field(self):
         # This register the DogNode type
@@ -119,16 +112,5 @@ class TestBatchUpdateMutationRequiredOutputField(TestCase):
 
         schema = Schema(query=DummyQuery, mutation=Mutations)
 
-        introspected = schema.introspect()
-        introspected_types = introspected.get("__schema", {}).get("types", [])
-        introspected_mutation = next(
-            filter(lambda t: t.get("name", None) == "BatchUpdateDogMutation", introspected_types), {}
-        )
-
-        self.assertIsNotNone(introspected_mutation)
-
-        introspected_fields = introspected_mutation.get("fields", [])
-        introspected_field = next(filter(lambda f: f.get("name", None) == "dogs", introspected_fields), {})
-        introspected_field_type = introspected_field.get("type", {}).get("kind", None)
-
-        self.assertNotEqual(introspected_field_type, "NON_NULL")
+        field_kind = get_introspected_field_kind(schema, "BatchUpdateDogMutation", "dogs")
+        self.assertNotEqual(field_kind, "NON_NULL")

--- a/graphene_django_cud/tests/test_create_mutation.py
+++ b/graphene_django_cud/tests/test_create_mutation.py
@@ -14,6 +14,7 @@ from graphene_django_cud.tests.factories import (
     FishFactory,
 )
 from graphene_django_cud.tests.models import User, Cat, Dog, DogRegistration, Fish
+from graphene_django_cud.tests.util import get_introspected_field_kind
 from graphene_django_cud.util import disambiguate_id
 
 
@@ -725,19 +726,8 @@ class TestCreateMutationRequiredOutputField(TestCase):
 
         schema = Schema(query=DummyQuery, mutation=Mutations)
 
-        introspected = schema.introspect()
-        introspected_types = introspected.get("__schema", {}).get("types", [])
-        introspected_mutation = next(
-            filter(lambda t: t.get("name", None) == "CreateFishMutation", introspected_types), {}
-        )
-
-        self.assertIsNotNone(introspected_mutation)
-
-        introspected_fields = introspected_mutation.get("fields", [])
-        introspected_field = next(filter(lambda f: f.get("name", None) == "fish", introspected_fields), {})
-        introspected_field_type = introspected_field.get("type", {}).get("kind", None)
-
-        self.assertEqual(introspected_field_type, "NON_NULL")
+        field_kind = get_introspected_field_kind(schema, "CreateFishMutation", "fish")
+        self.assertEqual(field_kind, "NON_NULL")
 
     def test__creating_a_record_without_required_output_field(self):
         # This register the FishNode type
@@ -753,16 +743,5 @@ class TestCreateMutationRequiredOutputField(TestCase):
 
         schema = Schema(query=DummyQuery, mutation=Mutations)
 
-        introspected = schema.introspect()
-        introspected_types = introspected.get("__schema", {}).get("types", [])
-        introspected_mutation = next(
-            filter(lambda t: t.get("name", None) == "CreateFishMutation", introspected_types), {}
-        )
-
-        self.assertIsNotNone(introspected_mutation)
-
-        introspected_fields = introspected_mutation.get("fields", [])
-        introspected_field = next(filter(lambda f: f.get("name", None) == "fish", introspected_fields), {})
-        introspected_field_type = introspected_field.get("type", {}).get("kind", None)
-
-        self.assertNotEqual(introspected_field_type, "NON_NULL")
+        field_kind = get_introspected_field_kind(schema, "CreateFishMutation", "fish")
+        self.assertNotEqual(field_kind, "NON_NULL")

--- a/graphene_django_cud/tests/test_filter_update_mutation.py
+++ b/graphene_django_cud/tests/test_filter_update_mutation.py
@@ -59,3 +59,63 @@ class TestFilterUpdateMutation(TestCase):
 
         dog.refresh_from_db()
         self.assertEqual("New tag", dog.tag)
+
+
+class TestUpdateMutationRequiredOutputField(TestCase):
+    def test__update_mutation_required_output_field(self):
+        # This register the DogNode type
+        from .schema import DogNode  # noqa: F401
+
+        class FilterUpdateDogMutation(DjangoFilterUpdateMutation):
+            class Meta:
+                model = Dog
+                filter_fields = ("name", "name__startswith")
+                required_output_field = True
+
+        class Mutations(graphene.ObjectType):
+            filter_update_dog = FilterUpdateDogMutation.Field()
+
+        schema = Schema(query=DummyQuery, mutation=Mutations)
+
+        introspected = schema.introspect()
+        introspected_types = introspected.get("__schema", {}).get("types", [])
+        introspected_mutation = next(
+            filter(lambda t: t.get("name", None) == "FilterUpdateDogMutation", introspected_types), {}
+        )
+
+        self.assertIsNotNone(introspected_mutation)
+
+        introspected_fields = introspected_mutation.get("fields", [])
+        introspected_field = next(filter(lambda f: f.get("name", None) == "updatedObjects", introspected_fields), {})
+        introspected_field_type = introspected_field.get("type", {}).get("kind", None)
+
+        self.assertEqual(introspected_field_type, "NON_NULL")
+
+    def test__update_mutation_without_required_output_field(self):
+        # This register the DogNode type
+        from .schema import DogNode  # noqa: F401
+
+        class FilterUpdateDogMutation(DjangoFilterUpdateMutation):
+            class Meta:
+                model = Dog
+                filter_fields = ("name", "name__startswith")
+                required_output_field = False
+
+        class Mutations(graphene.ObjectType):
+            filter_update_dog = FilterUpdateDogMutation.Field()
+
+        schema = Schema(query=DummyQuery, mutation=Mutations)
+
+        introspected = schema.introspect()
+        introspected_types = introspected.get("__schema", {}).get("types", [])
+        introspected_mutation = next(
+            filter(lambda t: t.get("name", None) == "FilterUpdateDogMutation", introspected_types), {}
+        )
+
+        self.assertIsNotNone(introspected_mutation)
+
+        introspected_fields = introspected_mutation.get("fields", [])
+        introspected_field = next(filter(lambda f: f.get("name", None) == "updatedObjects", introspected_fields), {})
+        introspected_field_type = introspected_field.get("type", {}).get("kind", None)
+
+        self.assertNotEqual(introspected_field_type, "NON_NULL")

--- a/graphene_django_cud/tests/test_filter_update_mutation.py
+++ b/graphene_django_cud/tests/test_filter_update_mutation.py
@@ -7,6 +7,7 @@ from graphene_django_cud.mutations.filter_update import DjangoFilterUpdateMutati
 from graphene_django_cud.tests.factories import DogFactory, UserFactory
 from graphene_django_cud.tests.dummy_query import DummyQuery
 from graphene_django_cud.tests.models import Dog
+from graphene_django_cud.tests.util import get_introspected_field_kind, get_introspected_list_field_item_kind
 
 
 class TestFilterUpdateMutation(TestCase):
@@ -77,19 +78,11 @@ class TestUpdateMutationRequiredOutputField(TestCase):
 
         schema = Schema(query=DummyQuery, mutation=Mutations)
 
-        introspected = schema.introspect()
-        introspected_types = introspected.get("__schema", {}).get("types", [])
-        introspected_mutation = next(
-            filter(lambda t: t.get("name", None) == "FilterUpdateDogMutation", introspected_types), {}
-        )
+        field_kind = get_introspected_field_kind(schema, "FilterUpdateDogMutation", "updatedObjects")
+        self.assertEqual(field_kind, "NON_NULL")
 
-        self.assertIsNotNone(introspected_mutation)
-
-        introspected_fields = introspected_mutation.get("fields", [])
-        introspected_field = next(filter(lambda f: f.get("name", None) == "updatedObjects", introspected_fields), {})
-        introspected_field_type = introspected_field.get("type", {}).get("kind", None)
-
-        self.assertEqual(introspected_field_type, "NON_NULL")
+        field_item_kind = get_introspected_list_field_item_kind(schema, "FilterUpdateDogMutation", "updatedObjects")
+        self.assertEqual(field_item_kind, "NON_NULL")
 
     def test__update_mutation_without_required_output_field(self):
         # This register the DogNode type
@@ -106,16 +99,5 @@ class TestUpdateMutationRequiredOutputField(TestCase):
 
         schema = Schema(query=DummyQuery, mutation=Mutations)
 
-        introspected = schema.introspect()
-        introspected_types = introspected.get("__schema", {}).get("types", [])
-        introspected_mutation = next(
-            filter(lambda t: t.get("name", None) == "FilterUpdateDogMutation", introspected_types), {}
-        )
-
-        self.assertIsNotNone(introspected_mutation)
-
-        introspected_fields = introspected_mutation.get("fields", [])
-        introspected_field = next(filter(lambda f: f.get("name", None) == "updatedObjects", introspected_fields), {})
-        introspected_field_type = introspected_field.get("type", {}).get("kind", None)
-
-        self.assertNotEqual(introspected_field_type, "NON_NULL")
+        field_kind = get_introspected_field_kind(schema, "FilterUpdateDogMutation", "updatedObjects")
+        self.assertNotEqual(field_kind, "NON_NULL")

--- a/graphene_django_cud/tests/test_patch_mutation.py
+++ b/graphene_django_cud/tests/test_patch_mutation.py
@@ -14,6 +14,7 @@ from graphene_django_cud.tests.factories import (
 )
 from graphene_django_cud.tests.dummy_query import DummyQuery
 from graphene_django_cud.tests.models import User, Cat, Dog
+from graphene_django_cud.tests.util import get_introspected_field_kind
 from graphene_django_cud.util import disambiguate_id
 
 
@@ -1638,19 +1639,8 @@ class TestPatchMutationRequiredOutputField(TestCase):
 
         schema = Schema(query=DummyQuery, mutation=Mutations)
 
-        introspected = schema.introspect()
-        introspected_types = introspected.get("__schema", {}).get("types", [])
-        introspected_mutation = next(
-            filter(lambda t: t.get("name", None) == "PatchDogMutation", introspected_types), {}
-        )
-
-        self.assertIsNotNone(introspected_mutation)
-
-        introspected_fields = introspected_mutation.get("fields", [])
-        introspected_field = next(filter(lambda f: f.get("name", None) == "dog", introspected_fields), {})
-        introspected_field_type = introspected_field.get("type", {}).get("kind", None)
-
-        self.assertEqual(introspected_field_type, "NON_NULL")
+        field_kind = get_introspected_field_kind(schema, "PatchDogMutation", "dog")
+        self.assertEqual(field_kind, "NON_NULL")
 
     def test__patch_mutation_without_required_output_field(self):
         # This register the DogNode type
@@ -1666,16 +1656,5 @@ class TestPatchMutationRequiredOutputField(TestCase):
 
         schema = Schema(query=DummyQuery, mutation=Mutations)
 
-        introspected = schema.introspect()
-        introspected_types = introspected.get("__schema", {}).get("types", [])
-        introspected_mutation = next(
-            filter(lambda t: t.get("name", None) == "PatchDogMutation", introspected_types), {}
-        )
-
-        self.assertIsNotNone(introspected_mutation)
-
-        introspected_fields = introspected_mutation.get("fields", [])
-        introspected_field = next(filter(lambda f: f.get("name", None) == "dog", introspected_fields), {})
-        introspected_field_type = introspected_field.get("type", {}).get("kind", None)
-
-        self.assertNotEqual(introspected_field_type, "NON_NULL")
+        field_kind = get_introspected_field_kind(schema, "PatchDogMutation", "dog")
+        self.assertNotEqual(field_kind, "NON_NULL")

--- a/graphene_django_cud/tests/test_update_mutation.py
+++ b/graphene_django_cud/tests/test_update_mutation.py
@@ -14,6 +14,7 @@ from graphene_django_cud.tests.factories import (
     FishFactory,
 )
 from graphene_django_cud.tests.models import User, Cat, Dog, Fish, DogRegistration
+from graphene_django_cud.tests.util import get_introspected_field_kind
 from graphene_django_cud.util import disambiguate_id
 from graphene_django_cud.tests.dummy_query import DummyQuery
 
@@ -1753,19 +1754,8 @@ class TestUpdateMutationRequiredOutputField(TestCase):
 
         schema = Schema(query=DummyQuery, mutation=Mutations)
 
-        introspected = schema.introspect()
-        introspected_types = introspected.get("__schema", {}).get("types", [])
-        introspected_mutation = next(
-            filter(lambda t: t.get("name", None) == "UpdateDogMutation", introspected_types), {}
-        )
-
-        self.assertIsNotNone(introspected_mutation)
-
-        introspected_fields = introspected_mutation.get("fields", [])
-        introspected_field = next(filter(lambda f: f.get("name", None) == "dog", introspected_fields), {})
-        introspected_field_type = introspected_field.get("type", {}).get("kind", None)
-
-        self.assertEqual(introspected_field_type, "NON_NULL")
+        field_kind = get_introspected_field_kind(schema, "UpdateDogMutation", "dog")
+        self.assertEqual(field_kind, "NON_NULL")
 
     def test__update_mutation_without_required_output_field(self):
         # This register the DogNode type
@@ -1781,16 +1771,5 @@ class TestUpdateMutationRequiredOutputField(TestCase):
 
         schema = Schema(query=DummyQuery, mutation=Mutations)
 
-        introspected = schema.introspect()
-        introspected_types = introspected.get("__schema", {}).get("types", [])
-        introspected_mutation = next(
-            filter(lambda t: t.get("name", None) == "UpdateDogMutation", introspected_types), {}
-        )
-
-        self.assertIsNotNone(introspected_mutation)
-
-        introspected_fields = introspected_mutation.get("fields", [])
-        introspected_field = next(filter(lambda f: f.get("name", None) == "dog", introspected_fields), {})
-        introspected_field_type = introspected_field.get("type", {}).get("kind", None)
-
-        self.assertNotEqual(introspected_field_type, "NON_NULL")
+        field_kind = get_introspected_field_kind(schema, "UpdateDogMutation", "dog")
+        self.assertNotEqual(field_kind, "NON_NULL")

--- a/graphene_django_cud/tests/util.py
+++ b/graphene_django_cud/tests/util.py
@@ -27,6 +27,10 @@ def get_introspected_field_kind(schema: Schema, mutation_name: str, field_name: 
 
 def get_introspected_list_field_item_kind(schema: Schema, mutation_name: str, field_name: str):
     field = get_introspected_field(schema, mutation_name, field_name)
-    kind = field.get("type", {}).get("ofType", {}).get("ofType", {}).get("kind", None)
+    field_of_type = field.get("type", {}).get("ofType", {})
+    if field_of_type.get("kind", None) != "LIST":
+        return None
+
+    kind = field_of_type.get("ofType", {}).get("kind", None)
 
     return kind

--- a/graphene_django_cud/tests/util.py
+++ b/graphene_django_cud/tests/util.py
@@ -1,0 +1,32 @@
+from graphene import Schema
+
+
+def get_introspected_mutation(schema: Schema, name: str):
+    introspected = schema.introspect()
+    types = introspected.get("__schema", {}).get("types", [])
+    mutation = next(filter(lambda t: t.get("name", None) == name, types), {})
+
+    return mutation
+
+
+def get_introspected_field(schema: Schema, mutation_name: str, field_name: str):
+    introspected_mutation = get_introspected_mutation(schema, mutation_name)
+
+    fields = introspected_mutation.get("fields", [])
+    field = next(filter(lambda f: f.get("name", None) == field_name, fields), {})
+
+    return field
+
+
+def get_introspected_field_kind(schema: Schema, mutation_name: str, field_name: str):
+    field = get_introspected_field(schema, mutation_name, field_name)
+    kind = field.get("type", {}).get("kind", None)
+
+    return kind
+
+
+def get_introspected_list_field_item_kind(schema: Schema, mutation_name: str, field_name: str):
+    field = get_introspected_field(schema, mutation_name, field_name)
+    kind = field.get("type", {}).get("ofType", {}).get("ofType", {}).get("kind", None)
+
+    return kind


### PR DESCRIPTION
Adds a mutation option, `required_output_field`.

For all relevant mutations, the `graphene.Field` for the mutation output is set without `required=True`. This leads to the relevant GraphQL type being `FishNode`, and not `FishNode!` for a mutation like this:

```graphql
mutation CreateFish($input: CreateFishInput!) {
  createFish(input: $input) {
    fish { # This is nullable, even though we know it should not be null
      id
      name
    }
  }
}
```

This is not normally an issue. However, a type generator (like [GraphQL-Codegen](https://the-guild.dev/graphql/codegen)), will then naturally make the type of the mutation result `T | null`, which is annoying to work around.

This PR solves the problem by introducing the `required_output_field` meta option for all mutations. If `True`, it sets `required=True` for all output model fields.

One question is whether this should be the default, since there are no scenarios (as far as I know) when the output field will actually be null if the above `createFish` is not null. This would technically be a breaking change, as it would alter the output schema of all apps using Graphene Django CUD, however I believe it would be extremely unlikely that it would actually break anything. It could perhaps also be a global configuration option.

Another question is the naming. `required_output_field` is perhaps not the best name. But naming is hard.