### PR TITLE
ci: queue approved PRs with Mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,37 @@
+queue_rules:
+  - name: default
+    queue_conditions:
+      - "base=main"
+      - "-draft"
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by=0"
+      - "label!=do-not-merge"
+      - "label!=work-in-progress"
+      - "label!=wip"
+    merge_conditions:
+      - "base=main"
+      - "-draft"
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by=0"
+      - "label!=do-not-merge"
+      - "label!=work-in-progress"
+      - "label!=wip"
+      - "check-success=test (3.9, 1.8.3)"
+      - "check-success=test (3.10, 1.8.3)"
+      - "check-success=test (3.11, 1.8.3)"
+      - "check-success=test (3.12, 1.8.3)"
+    merge_method: squash
+
+pull_request_rules:
+  - name: Queue approved PRs targeting main
+    conditions:
+      - "base=main"
+      - "-draft"
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by=0"
+      - "label!=do-not-merge"
+      - "label!=work-in-progress"
+      - "label!=wip"
+    actions:
+      queue:
+        name: default


### PR DESCRIPTION
## Summary
- Add Mergify merge queue configuration.
- Queue PRs targeting `main` as soon as they have at least one approval.
- Keep queued PRs blocked until all four Python matrix jobs pass.
- Block drafts, changes-requested reviews, and common do-not-merge/WIP labels.
- Squash merge from the queue.

## Notes
This intentionally lets approval be the human trigger; CI success is enforced as a merge condition before Mergify actually lands the PR.
