### PR TITLE
ci: queue ready-to-merge PRs with Mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,7 +3,6 @@ queue_rules:
     queue_conditions:
       - "base=main"
       - "-draft"
-      - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
       - "label!=do-not-merge"
       - "label!=work-in-progress"
@@ -11,7 +10,6 @@ queue_rules:
     merge_conditions:
       - "base=main"
       - "-draft"
-      - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
       - "label!=do-not-merge"
       - "label!=work-in-progress"
@@ -28,6 +26,19 @@ pull_request_rules:
       - "base=main"
       - "-draft"
       - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by=0"
+      - "label!=do-not-merge"
+      - "label!=work-in-progress"
+      - "label!=wip"
+    actions:
+      queue:
+        name: default
+
+  - name: Queue PRs labeled ready-to-merge targeting main
+    conditions:
+      - "base=main"
+      - "-draft"
+      - "label=ready-to-merge"
       - "#changes-requested-reviews-by=0"
       - "label!=do-not-merge"
       - "label!=work-in-progress"


### PR DESCRIPTION
## Summary
- Add a Mergify rule that queues PRs targeting `main` when labeled `ready-to-merge`.
- Keep the existing approval-based queue rule.
- Keep CI and safety gates: not draft, no changes requested, no WIP/do-not-merge labels, and all Python matrix checks green before merge.

## Notes
The queue rule keeps only common safety gates, while the pull request rules decide what is allowed to enter the queue: either approval or the `ready-to-merge` label.
