### PR TITLE
Ensure parent ID is set when using m2o extras with custom input type

### DIFF
--- a/graphene_django_cud/mutations/core.py
+++ b/graphene_django_cud/mutations/core.py
@@ -196,6 +196,11 @@ class DjangoCudBase(Mutation):
                     )
                     results.append(related_obj)
                 else:
+                    # Ensure the parent relation exists.
+                    # If no parent id was passed, set to passed parent obj's id.
+                    if not hasattr(value, field.field.name) or value[field.field.name] is None:
+                        value[field.field.name] = obj.pk
+
                     # Create new obj
                     related_obj = cls.create_obj(
                         value,


### PR DESCRIPTION
This should fix https://github.com/trmdy/graphene-django-cud/issues/102